### PR TITLE
Creates JWT token and saves it to cookie.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,4 @@ gem 'rails-healthcheck'
 
 gem 'omniauth-cas', '~> 2.0'
 gem 'omniauth-rails_csrf_protection', '~> 0.1'
+gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
       warden (~> 1.2.3)
     devise-guests (0.7.0)
       devise
+    diff-lcs (1.4.4)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dry-configurable (0.12.1)
@@ -230,6 +231,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    jwt (2.2.2)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -332,6 +334,23 @@ GEM
     rsolr (2.3.0)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-rails (5.0.1)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      railties (>= 5.2)
+      rspec-core (~> 3.10)
+      rspec-expectations (~> 3.10)
+      rspec-mocks (~> 3.10)
+      rspec-support (~> 3.10)
+    rspec-support (3.10.2)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
     ruby_dep (1.5.0)
@@ -429,6 +448,7 @@ DEPENDENCIES
   harvard-patterns-gem (= 0.1.0)!
   jbuilder (~> 2.5)
   jquery-rails
+  jwt
   listen (>= 3.0.5, < 3.2)
   mysql2
   omniauth-cas (~> 2.0)
@@ -437,6 +457,7 @@ DEPENDENCIES
   rails
   rails-healthcheck
   rsolr (>= 1.0, < 3)
+  rspec-rails (~> 5.0.0)
   sass-rails (~> 5.0)
   sassc (= 2.1.0)
   selenium-webdriver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 version: '3.8'
 services:
   app:
-    image: registry.lts.harvard.edu/lts/hgl:0.0.16
+    image: registry.lts.harvard.edu/lts/hgl:0.0.17
     build:
       context: .
       dockerfile: Dockerfile

--- a/env-example.txt
+++ b/env-example.txt
@@ -1,0 +1,19 @@
+# Environment `development`, `test`, or `production`
+RAILS_ENV=development
+MYSQL_ROOT_PASSWORD=root
+MYSQL_USER=geoblacklight_user
+MYSQL_PASSWORD=anexamplepassword
+MYSQL_DB=geoblacklight_local_db
+MYSQL_HOST=geoblacklight_db
+MYSQL_PORT=3306:3306
+SOLR_URL=<SOLR_URL>
+
+# JWT Secret
+JWT_SECRET_KEY=ARe@llyL0ngAndC0mpl3xStr1ngF0rS1gn1ngTok3ns
+JWT_ALGORITHM=HS512
+
+# Cookie to store JWT
+# Set to COOKIE_DOMAIN the app domain name
+# Set to 'localhost' for local development
+COOKIE_DOMAIN=app.example.com
+COOKIE_MAX_AGE_MINS=15


### PR DESCRIPTION
**Creates JWT token and saves it to cookie.**
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/HGL-428


# What does this Pull Request do?
When a user logs in using HarvardKey:
- A JWT token is created using secret key and JWT algorithm supplied in the .env file. 
- The token payload includes the displayName, email address and memberOf data supplied by HarvardKey
- It also creates a cookie called "hgl" that stores the token and sets the domain and max age using variables in the .env file.
- The env-example.txt file has been updated with the new variables and placeholder values.

This has been deployed to the Dev server already. I have updated the .env file there with the secret key etc.  

# How should this be tested?

After logging in you should see the "hgl" cookie in your browser storage with the encrypted token. TBD if this is all GeoServer needs. We may need to adjust the payload in the future, but that shouldn't hold up this PR.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@ives1227 