### PR TITLE
Miscellanous UI updates after testing and stakeholder feedback

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,7 +23,10 @@
 //= require bootstrap
 //= require blacklight/blacklight
 
+//= require leaflet-sleep
+
 //= require_tree .
+
 
 
 
@@ -82,11 +85,13 @@ $(document).on('turbolinks:load', function() {
     $('.active.accordion-navigation').each(function(){
       const $el = $(this);
       const $facetButton = $el.find(".facet__title");
+      const $facetToggle = $el.find(".facet-expand.toggle");
+      $facetToggle.removeClass("fa-rotate-180");
       $facetButton.attr('aria-expanded', 'true');
+
       const $facetContent = $el.find(".active.panel-collapse");
       $facetContent.addClass("show");
-      console.log($facetButton);
-    })
+    });
 
     // selected filters styled as display:flex to center close icon
     $('.active .facet-label').each(function(){
@@ -100,7 +105,7 @@ $(document).on('turbolinks:load', function() {
     // add class to homepage's #main-container to make full width
     $(".homepage").each(function(){
       $("#main-container").addClass("homepage__container");
-    })
+    });
 
 
     // function displayFlashMessage(message) {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -59,10 +59,48 @@ $(document).on('turbolinks:load', function() {
       $('.facets__rail').removeClass('open');
     });
 
+
+
     // index map explorer toggle closed
     $('body').on('click', '.index-map__close--btn', function(e){
       $('.viewer-information').slideUp();
     });
+
+
+    // attribution table toggle open/closed
+    $(".attribute-table").each(function(){
+      $("#map").on("click",function(e){
+        $('.attribute-table__table').slideDown();
+      })
+    })
+    $('body').on('click', '.attribute-table__close--btn', function(e){
+      $('.attribute-table__table').slideUp();
+    });
+
+
+    // keep selected filter categories open until clicked closed
+    $('.active.accordion-navigation').each(function(){
+      const $el = $(this);
+      const $facetButton = $el.find(".facet__title");
+      $facetButton.attr('aria-expanded', 'true');
+      const $facetContent = $el.find(".active.panel-collapse");
+      $facetContent.addClass("show");
+      console.log($facetButton);
+    })
+
+    // selected filters styled as display:flex to center close icon
+    $('.active .facet-label').each(function(){
+      const $el = $(this);
+      const $selected = $el.find("span.selected");
+      if ($selected.html() != null){
+        $el.addClass("selected");
+      }
+    });
+
+    // add class to homepage's #main-container to make full width
+    $(".homepage").each(function(){
+      $("#main-container").addClass("homepage__container");
+    })
 
 
     // function displayFlashMessage(message) {

--- a/app/assets/javascripts/bootstrap-accordion.js
+++ b/app/assets/javascripts/bootstrap-accordion.js
@@ -5,9 +5,9 @@ $(document).on('turbolinks:load', function () {
     $('#accordion .panel-collapse').collapse('hide');
     $('#accordion .expand_caret').addClass('fa-rotate-180');
   } else {
-    $('.toggle-all-facets .expand-text').hide();
-    $('.toggle-all-facets .collapse-text').show();
-    $('.toggle-all-facets').attr('aria-expanded', 'true');
+    // $('.toggle-all-facets .expand-text').show();
+    // $('.toggle-all-facets .collapse-text').hide();
+    // $('.toggle-all-facets').attr('aria-expanded', 'false');
   }
 
 

--- a/app/assets/javascripts/geoblacklight/modules/geosearch.js
+++ b/app/assets/javascripts/geoblacklight/modules/geosearch.js
@@ -29,7 +29,7 @@
   L.Control.GeoSearch = L.Control.extend({
 
     options: {
-      dynamic: false,
+      dynamic: true,
       baseUrl: '',
       searcher: function() {
         History.pushState(null, document.title, this.getSearchUrl());

--- a/app/assets/javascripts/geoblacklight/modules/item.js
+++ b/app/assets/javascripts/geoblacklight/modules/item.js
@@ -7,8 +7,32 @@ Blacklight.onLoad(function() {
 
     // get new viewer instance and pass in element
     viewer = new window['GeoBlacklight']['Viewer'][viewerName](element);
+
+    // choose more metadata fields to appear one per line
+    const onePerLine = ( fieldName ) => {
+      const $fieldLookup = "dd."+fieldName;
+      let $text = $($fieldLookup).html();
+
+      // check if field exists on item detail page
+      if ($text != null){
+        // remove commas, spaces, and
+        $text = $text.replace('> and ','>').replace('>, and ','>').replace(/>, /g,'>');
+
+        // adds shows more button if long list
+        let $newText = $($fieldLookup).html('<div class="truncate-abstract">' + $text + '</div>');
+
+        return $newText;
+      }
+    }
+
+    // calls the metadata we want as one per line
+    onePerLine("blacklight-dc_subject_sm");
+    onePerLine("blacklight-dct_spatial_sm");
   });
 
+
+
+  // truncation button
   $('.truncate-abstract').each(function(i, element) {
     var lines = 12 * parseFloat(getComputedStyle(element).fontSize);
     if (element.getBoundingClientRect().height < lines) return;
@@ -17,13 +41,31 @@ Blacklight.onLoad(function() {
     element.id = id;
     $(element).addClass('collapse');
 
-    var control = $('<button class="btn btn-link p-0 border-0" data-toggle="collapse" aria-expanded="false" data-target="#' + id + '" aria-controls="' + id + '">Read more</button>');
+    const $fieldName = $(this).parent().prop('className');
+    let $label = "";
+
+    if ($fieldName === "blacklight-dc_description_s col-md-9"){
+      $label = "description";
+    } else if ($fieldName === "blacklight-dct_spatial_sm col-md-9"){
+      $label = "places";
+    } else if ($fieldName === "blacklight-dc_subject_sm col-md-9"){
+      $label = "subjects";
+    };
+
+    let $showMore = "More " + $label;
+    let $showLess = "Fewer " + $label;
+
+    if ($label === "description"){
+      $showLess = "Less " + $label;
+    }
+
+    var control = $('<button class="btn btn-link p-0 border-0" data-toggle="collapse" aria-expanded="false" data-target="#' + id + '" aria-controls="' + id + '">' + $showMore + '</button>');
 
     $(element).on('show.bs.collapse', function() {
-      control.text('Show less');
+      control.text($showLess);
     });
     $(element).on('hide.bs.collapse', function() {
-      control.text('Read more');
+      control.text($showMore);
     });
 
     control.collapse();

--- a/app/assets/javascripts/geoblacklight/templates/index_map_info.hbs
+++ b/app/assets/javascripts/geoblacklight/templates/index_map_info.hbs
@@ -4,32 +4,38 @@
   </div>
   <div class="col-sm-12 index-map__table">
     {{#if thumbnailUrl}}
-      <img src="{{thumbnailUrl}}" class="img-responsive index-map__thumbnail">
+      {{#if websiteUrl}}
+        <a href="{{websiteUrl}}" class="index-map__thumbnail">
+          <img src="{{thumbnailUrl}}" class="img-responsive">
+        </a>
+      {{else}}
+        <img src="{{thumbnailUrl}}" class="index-map__thumbnail">
+      {{/if}}
     {{/if}}
     <dl class="row dl-invert document-metadata">
       {{#if title}}
-      <dt class="col-sm-3">Title</dt>
-      <dd class="col-sm-8 index-map__title">{{title}}</dd>
+      <dt class="col-sm-2">Title</dt>
+      <dd class="col-sm-9 index-map__title">{{title}}</dd>
       {{/if}}
       {{#if websiteUrl}}
-        <dt class="col-sm-3">Website</dt>
-        <dd class="col-sm-8"><a href="{{websiteUrl}}">{{websiteUrl}}</a></dd>
+        <dt class="col-sm-2">Website</dt>
+        <dd class="col-sm-9"><a href="{{websiteUrl}}">{{websiteUrl}}</a></dd>
       {{/if}}
       {{#if downloadUrl}}
-        <dt class="col-sm-3">Download</dt>
-        <dd class="col-sm-8"><a href="{{downloadUrl}}">{{downloadUrl}}</a></dd>
+        <dt class="col-sm-2">Download</dt>
+        <dd class="col-sm-9"><a href="{{downloadUrl}}">{{downloadUrl}}</a></dd>
       {{/if}}
       {{#if recordIdentifier}}
-        <dt class="col-sm-3">Call number</dt>
-        <dd class="col-sm-8">{{recordIdentifier}}</dd>
+        <dt class="col-sm-2">Call number</dt>
+        <dd class="col-sm-9">{{recordIdentifier}}</dd>
       {{/if}}
       {{#if label}}
-        <dt class="col-sm-3">Label</dt>
-        <dd class="col-sm-8">{{label}}</dd>
+        <dt class="col-sm-2">Label</dt>
+        <dd class="col-sm-9">{{label}}</dd>
       {{/if}}
       {{#if note}}
-        <dt class="col-sm-3">Note</dt>
-        <dd class="col-sm-8 index-map__note">{{note}}</dd>
+        <dt class="col-sm-2">Note</dt>
+        <dd class="col-sm-9 index-map__note">{{note}}</dd>
       {{/if}}
     </dl>
   </div>

--- a/app/assets/javascripts/geoblacklight/templates/index_map_info.hbs
+++ b/app/assets/javascripts/geoblacklight/templates/index_map_info.hbs
@@ -41,7 +41,7 @@
   </div>
   <div class="index-map__close">
     <button class="index-map__close--btn">
-      Close the index explorer
+      Close index explorer
     </button>
   </div>
 </div>

--- a/app/assets/javascripts/leaflet-sleep.js
+++ b/app/assets/javascripts/leaflet-sleep.js
@@ -1,0 +1,241 @@
+//= require leaflet
+
+/*
+ * Leaflet.Sleep
+ */
+
+/*
+ * Default Button (touch devices only)
+ */
+
+L.Control.SleepMapControl = L.Control.extend({
+
+  initialize: function(opts){
+    L.setOptions(this,opts);
+  },
+
+  options: {
+    position: 'topright',
+    prompt: 'disable map',
+    styles: {
+      'backgroundColor': 'white',
+      'padding': '5px',
+      'border': '2px solid gray'
+    }
+  },
+
+  buildContainer: function(){
+    var self = this;
+    var container = L.DomUtil.create('p', 'sleep-button');
+    var boundEvent = this._nonBoundEvent.bind(this);
+    container.innerHTML = this.options.prompt;
+    L.DomEvent.addListener(container, 'click', boundEvent);
+    L.DomEvent.addListener(container, 'touchstart', boundEvent);
+
+    Object.keys(this.options.styles).map(function(key) {
+      container.style[key] = self.options.styles[key];
+    });
+
+    return (this._container = container);
+  },
+
+  onAdd: function () {
+    return this._container || this.buildContainer();
+  },
+
+  _nonBoundEvent: function(e) {
+    L.DomEvent.stop(e);
+    if (this._map) this._map.sleep._sleepMap();
+    return false;
+  }
+
+});
+
+L.Control.sleepMapControl = function(){
+  return new L.Control.SleepMapControl();
+};
+
+
+/*
+ * The Sleep Handler
+ */
+
+L.Map.mergeOptions({
+  sleep: true,
+  sleepTime: 750,
+  wakeTime: 750,
+  wakeMessageTouch: 'Touch to Wake',
+  sleepNote: true,
+  hoverToWake: false,
+  sleepOpacity:.7,
+  sleepButton: L.Control.sleepMapControl
+});
+
+L.Map.Sleep = L.Handler.extend({
+
+  addHooks: function () {
+    var self = this;
+    this.sleepNote = L.DomUtil.create('p', 'sleep-note', this._map._container);
+    this._enterTimeout = null;
+    this._exitTimeout = null;
+
+    /*
+     * If the device has only a touchscreen we will never get
+     * a mouseout event, so we add an extra button to put the map
+     * back to sleep manually.
+     *
+     * a custom control/button can be provided by the user
+     * with the map's `sleepButton` option
+     */
+    this._sleepButton = this._map.options.sleepButton();
+
+    if (this._map.tap) {
+      this._map.addControl(this._sleepButton);
+    }
+
+    var mapStyle = this._map._container.style;
+    mapStyle.WebkitTransition += 'opacity .5s';
+    mapStyle.MozTransition += 'opacity .5s';
+
+    this._setSleepNoteStyle();
+    this._sleepMap();
+  },
+
+  removeHooks: function () {
+    if (!this._map.scrollWheelZoom.enabled()){
+      this._map.scrollWheelZoom.enable();
+    }
+    if (this._map.tap) {
+      this._map.touchZoom.enable();
+      this._map.dragging.enable();
+      this._map.tap.enable();
+    }
+    L.DomUtil.setOpacity( this._map._container, 1);
+    L.DomUtil.setOpacity( this.sleepNote, 0);
+    this._removeSleepingListeners();
+    this._removeAwakeListeners();
+  },
+
+  _setSleepNoteStyle: function() {
+    var noteString = '';
+    var style = this.sleepNote.style;
+
+    if(this._map.tap) {
+      noteString = this._map.options.wakeMessageTouch;
+    } else if (this._map.options.wakeMessage) {
+      noteString = this._map.options.wakeMessage;
+    } else if (this._map.options.hoverToWake) {
+      noteString = 'click or hover to wake';
+    } else {
+      noteString = 'click to wake';
+    }
+
+    if( this._map.options.sleepNote ){
+      this.sleepNote.innerHTML = noteString;
+      style.pointerEvents = 'none';
+      style.maxWidth = '150px';
+      style.transitionDuration = '.2s';
+      style.zIndex = 5000;
+      style.margin = 'auto';
+      style.textAlign = 'center';
+      style.borderRadius = '4px';
+      style.top = '50%';
+      style.position = 'relative';
+      style.padding = '5px';
+      style.border = 'solid 2px black';
+      style.background = 'white';
+
+      if(this._map.options.sleepNoteStyle) {
+        var noteStyleOverrides = this._map.options.sleepNoteStyle;
+        Object.keys(noteStyleOverrides).map(function(key) {
+          style[key] = noteStyleOverrides[key];
+        });
+      }
+    }
+  },
+
+  _wakeMap: function (e) {
+    this._stopWaiting();
+    this._map.scrollWheelZoom.enable();
+    if (this._map.tap) {
+      this._map.touchZoom.enable();
+      this._map.dragging.enable();
+      this._map.addControl(this._sleepButton);
+    }
+    L.DomUtil.setOpacity( this._map._container, 1);
+    this.sleepNote.style.opacity = 0;
+    this._addAwakeListeners();
+  },
+
+  _sleepMap: function () {
+    this._stopWaiting();
+    this._map.scrollWheelZoom.disable();
+
+    if (this._map.tap) {
+      this._map.touchZoom.disable();
+      this._map.dragging.disable();
+      this._map.tap.disable();
+      this._map.removeControl(this._sleepButton);
+    }
+
+    L.DomUtil.setOpacity( this._map._container, this._map.options.sleepOpacity);
+    this.sleepNote.style.opacity = this._map.options.sleepNoteStyle && this._map.options.sleepNoteStyle.opacity ? this._map.options.sleepNoteStyle.opacity : .6;
+    this._addSleepingListeners();
+  },
+
+  _wakePending: function () {
+    this._map.once('mousedown', this._wakeMap, this);
+    if (this._map.options.hoverToWake){
+      var self = this;
+      this._map.once('mouseout', this._sleepMap, this);
+      self._enterTimeout = setTimeout(function(){
+          self._map.off('mouseout', self._sleepMap, self);
+          self._wakeMap();
+      } , self._map.options.wakeTime);
+    }
+  },
+
+  _sleepPending: function () {
+    var self = this;
+    self._map.once('mouseover', self._wakeMap, self);
+    self._exitTimeout = setTimeout(function(){
+        self._map.off('mouseover', self._wakeMap, self);
+        self._sleepMap();
+    } , self._map.options.sleepTime);
+  },
+
+  _addSleepingListeners: function(){
+    this._map.once('mouseover', this._wakePending, this);
+    this._map.tap &&
+      this._map.once('click', this._wakeMap, this);
+
+  },
+
+  _addAwakeListeners: function(){
+    this._map.once('mouseout', this._sleepPending, this);
+  },
+
+  _removeSleepingListeners: function(){
+    this._map.options.hoverToWake &&
+      this._map.off('mouseover', this._wakePending, this);
+    this._map.off('mousedown', this._wakeMap, this);
+    this._map.tap &&
+      this._map.off('click', this._wakeMap, this);
+  },
+
+  _removeAwakeListeners: function(){
+    this._map.off('mouseout', this._sleepPending, this);
+  },
+
+  _stopWaiting: function () {
+    this._removeSleepingListeners();
+    this._removeAwakeListeners();
+    var self = this;
+    if(this._enterTimeout) clearTimeout(self._enterTimeout);
+    if(this._exitTimeout) clearTimeout(self._exitTimeout);
+    this._enterTimeout = null;
+    this._exitTimeout = null;
+  }
+});
+
+L.Map.addInitHook('addHandler', 'sleep', L.Map.Sleep);

--- a/app/assets/stylesheets/_harvard-bootstrap.scss
+++ b/app/assets/stylesheets/_harvard-bootstrap.scss
@@ -16,7 +16,7 @@ $indigo: #2a5280;
 $red: #eb001b;
 // $orange: #fd7e14;
 $yellow: #f8c21c;
-// $green: #28a745;
+$green: #017878;
 $teal: #3e6f7d;
 // $cyan: #17a2b8;
 $white: #fff;

--- a/app/assets/stylesheets/_harvard-bootstrap.scss
+++ b/app/assets/stylesheets/_harvard-bootstrap.scss
@@ -16,7 +16,7 @@ $indigo: #2a5280;
 $red: #eb001b;
 // $orange: #fd7e14;
 $yellow: #f8c21c;
-$green: #017878;
+// $green: #017878;
 $teal: #3e6f7d;
 // $cyan: #17a2b8;
 $white: #fff;

--- a/app/assets/stylesheets/gem/_facets.scss
+++ b/app/assets/stylesheets/gem/_facets.scss
@@ -206,7 +206,7 @@
 
           &.selected {
             display: flex;
-            align-items: center;
+            // align-items: center;
           }
 
           a {
@@ -234,13 +234,14 @@
         }
 
         // selected facets
-        // .selected {
-        //   color: $c-font-subtle !important;
-        //
-        //   &:not(.facet-count){
-        //     color: $c-theme-ink !important;
-        //   }
-        // }
+        .selected {
+          color: $c-font-subtle !important;
+          font-weight: 700;
+
+          &:not(.facet-count){
+            color: $c-theme-ink !important;
+          }
+        }
 
         // selceted facets icon
         a.remove {

--- a/app/assets/stylesheets/gem/_facets.scss
+++ b/app/assets/stylesheets/gem/_facets.scss
@@ -202,7 +202,12 @@
         .facet-label {
           padding: 0;
           text-indent: 0;
-          display: flex;
+          display: block;
+
+          &.selected {
+            display: flex;
+            align-items: center;
+          }
 
           a {
             color: $c-theme-ink;
@@ -223,33 +228,24 @@
           width: auto !important;
         }
 
-        // more link when a long list of facet values with new '_facet_limit.html.erb' file + modal view
-        // &.more_facets_link {
-        //   padding-right: 0;
-        //
-        //   a.more-link {
-        //     float: right;
-        //     margin-top: 0;
-        //   }
-        // }
-
         // hide missing icons
         .icon-missing {
           display: none;
         }
 
         // selected facets
-        .selected {
-          color: $c-font-subtle !important;
-
-          &:not(.facet-count){
-            color: $c-theme-ink !important;
-          }
-        }
+        // .selected {
+        //   color: $c-font-subtle !important;
+        //
+        //   &:not(.facet-count){
+        //     color: $c-theme-ink !important;
+        //   }
+        // }
 
         // selceted facets icon
         a.remove {
           border-bottom: 0;
+          height: 22px;
         }
 
       }
@@ -404,6 +400,16 @@
   .modal-body {
     .facet-label {
       padding-bottom: 0;
+
+      .selected {
+        color: $c-theme-ink;
+        font-size: 16px;
+        font-weight: 400;
+        line-height: 1.42;
+      }
+      a .remove-icon {
+        top: 8px;
+      }
     }
     .facet-select {
       color: $c-theme-ink;

--- a/app/assets/stylesheets/gem/_homepage.scss
+++ b/app/assets/stylesheets/gem/_homepage.scss
@@ -1,7 +1,25 @@
-.homepage {
-  @media($bp-large-min){
-    margin: -8px 0 -58px 0;
+// make homepage container full width
+#main-container.homepage__container {
+  max-width: 100%;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  padding-right: 0;
+
+  .container {
+    max-width: 100%;
+    padding-right: 0;
   }
+
+  & + .hl__footer {
+    margin-top: 0;
+  }
+}
+
+// homepage styles
+.homepage {
+  // @media($bp-large-min){
+  //   margin: -8px 0 -58px 0;
+  // }
 
   .row {
     @media($bp-large-max) {
@@ -59,15 +77,17 @@
   }
   .searchbar__wrapper {
     .input-group-append #search {
-      padding: 0 15px;
+      padding: 0 15px 0 0;
       background: transparent;
       border: 1px solid $c-bd-divider-dark;
+      border-left: none;
       color: $c-font-dark;
       white-space: nowrap;
 
       &:hover, &:focus {
         background: transparent;
         border: 1px solid $c-bd-divider-dark;
+        border-left: none;
         color: $c-font-subtle;
       }
     }
@@ -79,7 +99,7 @@
     }
 
     // magnifying glass behavior
-    #q.search-q.q.form-control.rounded-left.tt-input {
+    #q.search-q.q.form-control {
       @media ($bp-x-small-min) {
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='17' height='17' viewBox='0 0 17 17'%3E%3Cg%3E%3Cg transform='translate(-158 -656)'%3E%3Cpath d='M170.15 666.7l4.85 4.85-1.45 1.45-4.86-4.85v-.77l-.26-.27a6.32 6.32 0 1 1 .68-.68l.27.26zm-5.83 0a4.37 4.37 0 1 0 .01-8.74 4.37 4.37 0 0 0-.01 8.73z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E ");
         background-position: left 18px center;
@@ -95,8 +115,17 @@
 
       &:focus {
         background-position: left -35px center;
-        padding-left: 10px;
+        padding-left: 12px;
       }
+    }
+  }
+
+  // browse button
+  .hl__button--blue {
+    margin: 0 auto 50px;
+
+    &:hover, &:focus {
+      color: $c-white;
     }
   }
 
@@ -134,9 +163,11 @@
   @media($bp-large-min){
     &__map {
       height: 100%;
+      // width: 100%;
 
       #map[data-map="home"] {
         height: 100%;
+        // width: 100%;
         // background: #d4dadc;
         background: $c-gray-dfdfdf;
       }

--- a/app/assets/stylesheets/gem/_index-map-explorer.scss
+++ b/app/assets/stylesheets/gem/_index-map-explorer.scss
@@ -1,5 +1,5 @@
 // closed
-.index-map__directions {
+.index-map__directions, .attribute-table__directions {
   padding-top:10px;
   padding-left: 20px;
   color: $c-theme-blue;
@@ -17,6 +17,8 @@
 
 // open
 .viewer-information.col-sm-12 {
+  display: none;
+
   .index-map-info {
     background: $background-gray;
     margin-top: 0px;
@@ -34,8 +36,7 @@
       }
     }
     .index-map__table {
-      display: grid;
-      grid-template-columns: auto auto;
+      display: flex;
 
       @media($bp-small-max) {
         display: block;
@@ -43,9 +44,17 @@
     }
     .index-map__thumbnail {
       display: inline-block;
-      width: 200px;
-      margin-right: 20px;
-      margin-bottom: 20px;
+      width: 100%;
+      max-width: 200px;
+      height: 100%;
+      max-height: 200px;
+      margin-bottom: 30px;
+
+      @media($bp-small-min){
+        + dl {
+          margin-left: 30px;
+        }
+      }
     }
     .index-map__title {
       font-weight: 700;
@@ -71,13 +80,15 @@
       	font-size: 15px;
         border-bottom: none;
         margin-right: 20px;
+        min-width: 130px;
 
         @media($bp-large-max) {
           padding-bottom: 0;
         }
       }
       .hl__button--small {
-        width: 350px;
+        max-width: 350px;
+        width: 100%;
         text-align: center;
       }
     }
@@ -106,14 +117,52 @@
 
 
 
-// tables
-.row #table-container {
-  overflow: unset;
-  max-height: 100%;
-  font-size: 15px;
+// attribute tables
+.attribute-table {
+  // directions
+  &__directions {
+    padding-left: 0;
+  }
 
-  .table th,
-  .table td {
-    padding: 0.5em;
+  // table
+  &__table {
+    display: none;
+    position: relative;
+    background: $background-gray;
+
+    #table-container {
+      // overflow: unset;
+      // max-height: 400px;
+      font-size: 15px;
+      margin-top: 0;
+      padding-top: 20px;
+
+      .table th,
+      .table td {
+        padding: 0.5em;
+      }
+
+      a {
+        font-size: 15px;
+        font-family: Lora;
+        font-weight: normal;
+      }
+    }
+  }
+
+  // close button
+  &__close {
+    text-align: right;
+    padding: 0 20px 20px 20px;
+
+    &--btn {
+      margin-top: 20px;
+      background: transparent;
+      &::after {
+        border-left: 0.425em solid transparent;
+        border-bottom: 0.5em solid currentColor;
+        border-right: 0.425em solid transparent;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/gem/_item-detail.scss
+++ b/app/assets/stylesheets/gem/_item-detail.scss
@@ -71,6 +71,12 @@
       font-size: 15px;
       font-family: Lora;
       font-weight: 400;
+
+      .truncate-abstract {
+        span {
+          display: block;
+        }
+      }
     }
 
     dt {
@@ -80,6 +86,7 @@
       text-transform: uppercase;
       color: $c-font-dark;
       text-align: left !important;
+      white-space: nowrap;
     }
 
     dt.col-md-3::after {
@@ -103,6 +110,12 @@
     }
   }
 
+  // truncated text height
+  #document .truncate-abstract.collapse:not(.show), #document .truncate-abstract.collapsing{
+    min-height: 10.3rem;
+    max-height: 10.3rem;
+  }
+
   /* button styled as link + down-facing arrow */
   .truncate-abstract + button::after {
   	border-left: 0.425em solid transparent;
@@ -121,6 +134,10 @@
 
   // sidebar styling
   .page-sidebar {
+    > * {
+      margin-top: 20px;
+    }
+
     .card {
       font-family: $f-trueno;
       font-size: 15px;
@@ -142,28 +159,30 @@
         padding: 20px 40px 40px 40px;
       }
 
-      // tools & related links card
-      &.show-tools {
-        .list-group {
-          margin: 0;
+      .list-group {
+        margin: 0;
 
-          .list-group-item {
+        .list-group-item {
+          padding: 0;
+
+          a:not(.btn), .checkbox .toggle-bookmark {
+            display: inline;
+            font-size: 15px;
+            font-weight: 500;
+            line-height: normal;
             padding: 0;
+          }
 
-            a:not(.btn), .checkbox .toggle-bookmark {
-              display: inline-block;
-              font-size: 15px;
-              font-weight: 500;
-              line-height: normal;
-              padding: 0;
-            }
-
-            label.toggle-bookmark {
-              min-width: auto;
-              cursor: pointer;
-            }
+          label.toggle-bookmark {
+            min-width: auto;
+            cursor: pointer;
           }
         }
+      }
+
+      // tools & related links card
+      &.show-tools {
+
 
         // card sections
         .card-downloads, .card-exports, .card-authentication {
@@ -205,6 +224,10 @@
           a {
             padding: 5px 9px;
             max-width: 350px;
+          }
+
+          li:not(:first-child) a {
+            margin-top: 8px;
           }
         }
 

--- a/app/assets/stylesheets/gem/_links-and-buttons.scss
+++ b/app/assets/stylesheets/gem/_links-and-buttons.scss
@@ -3,6 +3,7 @@ a,
 #appliedParams a.btn,
 .page-sidebar .card .card-exports .btn /* export buttons */,
 .index-map__close--btn /* close the index explorer */,
+.attribute-table__close--btn /* close the attribute table */,
 .page-sidebar label.toggle-bookmark /* bookmark checkbox label */ {
   font-family: $f-trueno;
   font-size: 17px;
@@ -51,7 +52,8 @@ a.dark-link {
 // right arrow links
 a.more-link,
 .more_facets a,
-.index-map__close--btn /* close the index explorer */ {
+.index-map__close--btn /* close the index explorer */,
+.attribute-table__close--btn /* close the attribute table */ {
   text-transform: uppercase;
   font-size: 14px;
   font-weight: 600;

--- a/app/assets/stylesheets/gem/_search-results.scss
+++ b/app/assets/stylesheets/gem/_search-results.scss
@@ -101,6 +101,8 @@
   // map
   #map {
     z-index: 2; // prevents map from appearing on top of filter rail when slides open in mobile view
+    position: sticky !important;
+    top: 20px;
   }
   #main-container [data-map="index"] {
     @media($bp-medium-min){

--- a/app/assets/stylesheets/gem/_searchbar.scss
+++ b/app/assets/stylesheets/gem/_searchbar.scss
@@ -70,6 +70,10 @@
       margin-top: 20px;
     }
   }
+
+  #q.form-control:focus::placeholder {
+    opacity: 0;
+  }
 }
 
 // search contraint buttons

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -264,7 +264,7 @@ class CatalogController < ApplicationController
     config.basemap_provider = 'positron'
 
     # Configuration for autocomplete suggestor
-    config.autocomplete_enabled = true
+    config.autocomplete_enabled = false
     config.autocomplete_path = 'suggest'
   end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -144,7 +144,7 @@ class CatalogController < ApplicationController
     config.add_show_field Settings.FIELDS.PROVENANCE, label: 'Held by', link_to_facet: true
     config.add_show_field(
       Settings.FIELDS.REFERENCES,
-      label: 'More details at',
+      label: 'More details',
       accessor: [:external_url],
       if: proc { |_, _, doc| doc.external_url },
       helper_method: :render_references_url

--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,10 +1,10 @@
 <dl id="accordion" role="tablist" aria-multiselectable="true" class="panel-group accordion facet_limit blacklight-<%= facet_field.key.parameterize %>" data-accordion>
   <dd role="tab" id="<%= facet_field.key %>" class="accordion-navigation <%= 'active' if facet_field_in_params?(facet_field.key) %>">
-    <a role="button" class="facet__title" data-toggle="collapse" data-parent="#accordion" href="#<%= facet_field_id(facet_field) %>" aria-expanded="true" aria-controls="#<%= facet_field_id(facet_field) %>">
+    <a role="button" class="facet__title collapsed" data-toggle="collapse" data-parent="#accordion" href="#<%= facet_field_id(facet_field) %>" aria-expanded="false" aria-controls="#<%= facet_field_id(facet_field) %>">
       <%= facet_field_label(facet_field.key) %>
-      <span class="fa facet-expand toggle expand_caret"></span>
+      <span class="fa facet-expand toggle expand_caret fa-rotate-180"></span>
     </a>
-    <div id="<%= facet_field_id(facet_field) %>" class="panel-collapse collapse in content show <%= 'active' if facet_field_in_params?(facet_field.key) %>" role="tabpanel" aria-labelledby="<%= facet_field.key %>">
+    <div id="<%= facet_field_id(facet_field) %>" class="panel-collapse collapse in content <%= 'active' if facet_field_in_params?(facet_field.key) %>" role="tabpanel" aria-labelledby="<%= facet_field.key %>">
       <%= yield %>
     </div>
   </dd>

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -7,7 +7,10 @@
       </h2>
       <button class="btn-hide-facets" type="button"><span class="sr-only">Close</span><span class="angle-double-left"></span></button>
       <div class="toggle-wrapper">
-		    <button class="toggle-all-facets" type="button"><span class="expand-text">Expand All <span class="fa fa-caret-down"></span></span><span class="collapse-text">Collapse All <span class="fa fa-caret-up"></span></span></button>
+		    <button class="toggle-all-facets" type="button">
+          <span class="expand-text">Expand All <span class="fa fa-caret-down"></span></span>
+          <span class="collapse-text">Collapse All <span class="fa fa-caret-up"></span></span>
+        </button>
 	    </div>
       <div id="facets" class="facets__container">
         <div id="facet-panel-collapse" class="panel-group">

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,7 +1,7 @@
 <div class='container homepage'>
   <div class='row'>
     <!-- COLUMN 1 -->
-    <div class='col-sm-6'>
+    <div class='col-sm-5'>
 
       <!-- TITLE -->
       <h1>Harvard<br><span>Geospatial Library</span></h1>
@@ -15,45 +15,58 @@
       <%= content_tag :h2, t('geoblacklight.home.category_heading') %>
 
       <!-- CATEGORY OPTIONS -->
+      <div class="row">
+        <div class="category-block col-sm">Block 1</div>
+        <div class="category-block col-sm">Block 2</div>
+      </div>
+      <div class="row">
+        <div class="category-block col-sm">Block 3</div>
+        <div class="category-block col-sm">Block 4</div>
+      </div>
+      <div class="row homepage__browse">
+        <a href="/?utf8=✓&search_field=all_fields&q=" class="hl__button--blue">Browse all</a>
+      </div>
+
+
       <!-- SUBJECT -->
-      <div class="homepage__category">
+      <!-- <div class="homepage__category">
         <%= geoblacklight_icon('tags') %>
         <%= content_tag :h3, t('geoblacklight.home.subject') %>
       </div>
       <div class="homepage__links">
         <%= render_facet_tags [Settings.FIELDS.SUBJECT] %>
-      </div>
+      </div> -->
 
       <!-- PLACENAME -->
-      <div class="homepage__category">
+      <!-- <div class="homepage__category">
         <%= geoblacklight_icon('globe') %>
         <%= content_tag :h3, t('geoblacklight.home.placename') %>
       </div>
       <div class="homepage__links">
         <%= render_facet_tags [Settings.FIELDS.SPATIAL_COVERAGE] %>
-      </div>
+      </div> -->
 
       <!-- REPOSITORY -->
-      <div class="homepage__category">
+      <!-- <div class="homepage__category">
         <%= geoblacklight_icon('home') %>
         <%= content_tag :h3, t('geoblacklight.home.institution') %>
       </div>
       <div class="homepage__links">
         <%= render_facet_tags [Settings.FIELDS.PROVENANCE] %>
-      </div>
+      </div> -->
 
       <!-- DATA TYPE -->
-      <div class="homepage__category">
+      <!-- <div class="homepage__category">
         <%= geoblacklight_icon('arrow-circle-down') %>
         <%= content_tag :h3, t('geoblacklight.home.data_type') %>
       </div>
       <div class="homepage__links">
         <%= render_facet_tags [Settings.FIELDS.GEOM_TYPE] %>
-      </div>
+      </div> -->
     </div>
 
     <!-- COLUMN 2  -->
-    <div class='col-sm-6'>
+    <div class='col-sm-7'>
       <!-- VISUALLY HIDDEN H2 -->
       <%= content_tag :h2, t('geoblacklight.home.map_heading') %>
 

--- a/app/views/catalog/_show_default_attribute_table.html.erb
+++ b/app/views/catalog/_show_default_attribute_table.html.erb
@@ -35,7 +35,7 @@
       </div>
       <div class="attribute-table__close">
         <button class="attribute-table__close--btn">
-          Close the attribute table
+          Close attribute table
         </button>
       </div>
     </div>

--- a/app/views/catalog/_show_default_attribute_table.html.erb
+++ b/app/views/catalog/_show_default_attribute_table.html.erb
@@ -1,0 +1,43 @@
+<% if show_attribute_table? %>
+  <div class='attribute-table'>
+    <div class="attribute-table__directions">
+      Click map to inspect values
+      <span>
+        <svg width="16px" height="18px" viewBox="0 0 16 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <title>Pointer finger</title>
+          <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+              <g transform="translate(-503.000000, -808.000000)" fill="#0579B8" fill-rule="nonzero">
+                  <g transform="translate(293.000000, 805.000000)">
+                      <g id="hand-pointer" transform="translate(210.000000, 3.000000)">
+                          <path d="M16,8.4375 L16,11.8125 C16,11.9209219 15.9872857,12.0290273 15.9620357,12.1346016 L14.8191787,16.9158516 C14.6673572,17.5510547 14.0915001,18 13.4285716,18 L6,18 C5.54294795,18 5.11348956,17.7847161 4.8446437,17.4208711 L0.273322623,11.2333711 C-0.190713056,10.6052695 -0.0496416381,9.72576563 0.588394028,9.26898047 C1.22650112,8.81216016 2.11996534,8.9510625 2.58400102,9.57916406 L3.71428665,11.1090938 L3.71428665,1.40625 C3.71428665,0.629613281 4.35385803,0 5.14285797,0 C5.93185791,0 6.57142929,0.629613281 6.57142929,1.40625 L6.57142929,8.4375 L6.85714355,8.4375 L6.85714355,7.03125 C6.85714355,6.25461328 7.49671493,5.625 8.28571487,5.625 C9.07471481,5.625 9.71428619,6.25461328 9.71428619,7.03125 L9.71428619,8.4375 L10,8.4375 L10,7.59375 C10,6.81711328 10.6395718,6.1875 11.4285718,6.1875 C12.2175717,6.1875 12.8571431,6.81711328 12.8571431,7.59375 L12.8571431,8.4375 L13.1428574,8.4375 C13.1428574,7.66086328 13.7824287,7.03125 14.5714287,7.03125 C15.3604286,7.03125 16,7.66086328 16,8.4375 Z" id="Shape"></path>
+                      </g>
+                  </g>
+              </g>
+          </g>
+      </svg>
+      </span>
+    </div>
+    <div class="attribute-table__table">
+      <div id='table-container' class='col-md-12'>
+        <table id="attribute-table" class="table table-hover table-condensed table-striped table-bordered col-md-12">
+          <thead>
+            <tr>
+              <th><%= t('geoblacklight.show.attribute') %></th>
+              <th><%= t('geoblacklight.show.value') %></th>
+            </tr>
+          </thead>
+          <tbody class='attribute-table-body'>
+            <tr>
+              <td class='default-text' colspan='2'><em><%= t('geoblacklight.show.click_map') %></em></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="attribute-table__close">
+        <button class="attribute-table__close--btn">
+          Close the attribute table
+        </button>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -16,6 +16,15 @@
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
 
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-SQTW371VPB"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-SQTW371VPB');
+    </script>
   </head>
   <body class="<%= render_body_class %>">
     <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<%= content_tag :html, class: 'no-js', **html_tag_attributes do %>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Internet Explorer use the highest version available -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <title><%= render_page_title %></title>
+    <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
+    <%= favicon_link_tag %>
+    <%= stylesheet_link_tag "application", media: "all" %>
+    <%= javascript_include_tag "application" %>
+    <%= csrf_meta_tags %>
+    <%= content_for(:head) %>
+
+  </head>
+  <body class="<%= render_body_class %>">
+    <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
+      <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+      <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+      <%= content_for(:skip_links) %>
+    </nav>
+    <%= render partial: 'shared/header_navbar' %>
+
+  <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
+    <%= content_for(:container_header) %>
+
+    <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+
+    <div class="row">
+      <%= content_for?(:content) ? yield(:content) : yield %>
+    </div>
+  </main>
+
+    <%= render partial: 'shared/footer' %>
+    <%= render partial: 'shared/modal' %>
+  </body>
+<% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -18,7 +18,7 @@
 							<a class="hl__link-tag" href="https://harvard.az1.qualtrics.com/jfe/form/SV_6MyQ7lfQCn69OpD" title="Report a problem or provide feedback"><span>Report a problem</span></a>
 						</li>
 						<li class="hl__footer-nav__item">
-							<a class="hl__link-tag" href="bit.ly/LibraryGISCanvas" title=""><span>GIS in the libraries (Canvas)</span></a>
+							<a class="hl__link-tag" href="https://bit.ly/LibraryGISCanvas" title=""><span>GIS in the libraries (Canvas)</span></a>
 						</li>
 						<li class="hl__footer-nav__item">
 							<a class="hl__link-tag" href="https://library.harvard.edu/services-tools/digital-mapping-and-gis-support" title="Digital mapping and GIS support"><span>Digital mapping and GIS support</span></a>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -38,7 +38,7 @@
         <div class="search-constraints">
           <%= render_constraints(params) %>
           <div class="facets__clearall">
-            <%=link_to 'Clear All', search_catalog_path, :class => "" %>
+            <a class="" href="/?utf8=✓&search_field=all_fields&q=">Clear All</a>
           </div>
         </div>
       <% end %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -6,7 +6,7 @@ en:
       form:
         search:
           label: 'search for'
-          placeholder: 'Try "population data"'
+          placeholder: 'Try "population data" or "Cambridge"'
       facets:
         title: 'Limit Your Search'
         more_html: 'More <span class="sr-only">%{field_name}</span>'

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -8,3 +8,6 @@ en:
       headline: 'Harvard Geospatial Library'
       category_heading: 'Find by category'
       institution: 'Repository'
+
+    metadata:
+      more_details: 'More details'

--- a/config/locales/geoblacklight.en.yml
+++ b/config/locales/geoblacklight.en.yml
@@ -7,7 +7,6 @@ en:
     home:
       headline: 'Harvard Geospatial Library'
       category_heading: 'Find by category'
-      institution: 'Repository'
 
     metadata:
       more_details: 'More details'


### PR DESCRIPTION
**Miscellanous UI updates after testing and stakeholder feedback**
* * *

**JIRA Tickets**:
* [HGL-345: Apply library design styles](https://jira.huit.harvard.edu/browse/HGL-345)
* [HGL-355: Enable "click to wake" function for map search](https://jira.huit.harvard.edu/browse/HGL-355)
* [HGL-416: Expand/collapse verbose metadata field](https://jira.huit.harvard.edu/browse/HGL-416)
* [HGL-463: Insert Google Analytics Tag script into HGL markup](https://jira.huit.harvard.edu/browse/HGL-463)

# What does this Pull Request do?
Incorporating UI updates after testing and stakeholder feedback to create a better user experience.

# How should this be tested?
**Homepage**
* Search box
   * Updated placeholder text to say 'Try "population data" or "Cambridge"'
   * When click into the search box, placeholder text should disappear
   * Turned off autocomplete for search box, so when you're typing you shouldn't get a dropdown of titles/suggested searches
* "Click to wake" functionality added and appears on all maps; map initially appears with an opacity layer over it that disappears after clicking the button; scrolling off map will eventually cause it "sleep" again (we can also adjust how long the sleep/wake states are if we want something different than the default, [see options](https://github.com/harvard-huit/Harvard-Geospatial-Library/blob/9849b54defb6c6789bef7b2e7c76eaa8415f78c8/app/assets/javascripts/leaflet-sleep.js#L63-L72))
* Updated broken footer link for "GIS in the libraries (Canvas)" *note: the contact email is going to be updated with a new hgl_ref email once that is set up
* Google Analytics tag can be found in the document head (included at the bottom of the head element, look for 'Global site tag (gtag.js) - Google Analytics' commented out); can also be found in the [base.html.erb file](https://github.com/harvard-huit/Harvard-Geospatial-Library/commit/95a89e310c0ae2c9de61b33d5ffb61c953d8ffda)
* Started reworking the homepage layout, but final product will be in the development__homepage-revised branch, so other things can be ignored for now

**Search results page**
* Map sticks to top of page when scrolling through a long list of search results
* Clicking the "Clear all" link should remove all facets, but keep you on the search results page (before it was bouncing users back to the homepage)
* Filter rail + facets
   * Collapsed by default
   * When you select a facet, that category will remain open as the page reloads, but categories with unselected facets will collapse again
   * Facet links are displayed as block elements so all words will be underlined on hover (previous it was a flex element and lengthy facet links only had one big underline at the bottom of its flex box)
   * Restyled selected facets: bold text and "x" icon aligns with the top line for lengthy facets 

**Item detail page**
* Sidebar (discovered a few tweaks to the cards that needed to be made after more items were included in our test set)
   * New "Derived Datasets" card styled with same sizes and padding as other cards (test case: [2016 NYC Geodatabase, ArcGIS Version (jan2016)](https://localhost:3001/catalog/nyu_2451_34636)) *applied styles should now be generic enough to account for other cards that may appear up when we have more complete data
   * Padding added between buttons when there are multiple download buttons for an item (test case: [A new & accurate map of Asia](https://localhost:3001/catalog/57f0f116-b64e-4773-8684-96ba09afb549))
* Metatdata
   * "Place(s)" and "Subject(s)" now appear as one item per line (test case: [1-Meter Shaded Relief Multibeam Bathymetry Image](https://localhost:3001/catalog/stanford-dp018hs9766))
   * If there are more then 6 items, the field gets truncated and buttons appear to toggle more/less items (test case: [1:1,000,000-Scale National Wilderness Preservation System of the United States, 2014](https://localhost:3001/catalog/stanford-gd328br6434))
   * Metadata field simplified from "More details at" to "More details" (can view this with either test case above)
* Index map (test case: [Dabao Kinbōzu, Maps Index](https://localhost:3001/catalog/stanford-fb897vt9938))
   * Tray now slides down on first click (used to just quickly appear on the first click, but would slide down correctly after it was closed and reopened)
   * Reformatted table so that there's less space between the metadata titles and descriptions
   * Re-added website URL to the thumbnail image so that it's a clickable link (note: more to say about this and what i discovered in [HGL-374 ticket](https://jira.huit.harvard.edu/browse/HGL-374))
* Attribution table (test case: [2005 Rural Poverty GIS Database: Uganda](https://localhost:3001/catalog/stanford-cz128vq0535))
   * Re-added the scroll bar to account for long tables
   * Now behaves like the index map dropdown tray (has instructions with the pointer icon and the tray can be opened/closed at user interacts with the map)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz
@phil-plencner-hl 