### PR TITLE
Hyperlinked additional metadata fields + bug fix

### DIFF
--- a/app/assets/javascripts/geoblacklight/modules/item.js
+++ b/app/assets/javascripts/geoblacklight/modules/item.js
@@ -28,6 +28,7 @@ Blacklight.onLoad(function() {
     // calls the metadata we want as one per line
     onePerLine("blacklight-dc_subject_sm");
     onePerLine("blacklight-dct_spatial_sm");
+    onePerLine("blacklight-dc_creator_sm");
   });
 
 
@@ -44,12 +45,14 @@ Blacklight.onLoad(function() {
     const $fieldName = $(this).parent().prop('className');
     let $label = "";
 
-    if ($fieldName === "blacklight-dc_description_s col-md-9"){
+    if ($fieldName.includes("blacklight-dc_description_s")){
       $label = "description";
-    } else if ($fieldName === "blacklight-dct_spatial_sm col-md-9"){
+    } else if ($fieldName.includes("blacklight-dct_spatial_sm")){
       $label = "places";
-    } else if ($fieldName === "blacklight-dc_subject_sm col-md-9"){
+    } else if ($fieldName.includes("blacklight-dc_subject_sm")){
       $label = "subjects";
+    } else if ($fieldName.includes("blacklight-dc_creator_sm")){
+      $label = "authors";
     };
 
     let $showMore = "More " + $label;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -134,10 +134,10 @@ class CatalogController < ApplicationController
     # item_prop: [String] property given to span with Schema.org item property
     # link_to_search: [Boolean] that can be passed to link to a facet search
     # helper_method: [Symbol] method that can be used to render the value
-    config.add_show_field Settings.FIELDS.CREATOR, label: 'Author(s)', itemprop: 'author'
+    config.add_show_field Settings.FIELDS.CREATOR, label: 'Author(s)', itemprop: 'author', link_to_facet: true
     config.add_show_field Settings.FIELDS.DESCRIPTION, label: 'Description', itemprop: 'description', helper_method: :render_value_as_truncate_abstract
     config.add_show_field Settings.FIELDS.PUBLISHER, label: 'Publisher', itemprop: 'publisher'
-    config.add_show_field Settings.FIELDS.PART_OF, label: 'Collection', itemprop: 'isPartOf'
+    config.add_show_field Settings.FIELDS.PART_OF, label: 'Collection', itemprop: 'isPartOf', link_to_facet: true
     config.add_show_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Place(s)', itemprop: 'spatial', link_to_facet: true
     config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject(s)', itemprop: 'keywords', link_to_facet: true
     config.add_show_field Settings.FIELDS.TEMPORAL, label: 'Year', itemprop: 'temporal'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -19,6 +19,7 @@ en:
           one: 'Showing <strong>%{start_num}</strong> to <strong>%{end_num}</strong> of <strong>%{total_num}</strong> results'
           other: 'Showing <strong>%{start_num}</strong> to <strong>%{end_num}</strong> of <strong>%{total_num}</strong> results'
     back_to_search: '« Back to Search Results'
+    back_to_bookmarks: '« Back to Bookmarks'
     search_history:
       clear:
         action_title: 'Delete Search History'


### PR DESCRIPTION
**Hyperlinked additional metadata fields + bug fix**
* * *

**JIRA Ticket**: [HGL-416: Expand/collapse verbose metadata field](https://jira.huit.harvard.edu/browse/HGL-416)

# What does this Pull Request do?
* Turns author(s) facets and collection facet into hyperlinks as requested by stakeholders
* Fixes bug found with metadata toggle button

# How should this be tested?
Two test cases should cover everything: [Algeria, Morocco, Spain, 1996, Tactical Pilotage Chart](https://localhost:3001/catalog/harvard-am-tpc-g01cl) and [2015 New York City Subway Complexes and Ridership](https://localhost:3001/catalog/nyu_2451_34502)
* Test that author(s) and collection fields are hyperlinked correctly (should send you back to search results filtered by whatever facet you clicked on)
* If multiple authors exist, will appear as one per line and truncate if more than 6 authors exist (which doesn't in our current test set, but it's following the same logic at places and subjects and should work)
* Toggle buttons for different categories should read:
   * More description/Less description
   * More places/Fewer places
   * More subjects/Fewer subjects

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@phil-plencner-hl 
@enriquediaz 