### PR TITLE
Index map image links to viewer

### DIFF
--- a/app/assets/javascripts/geoblacklight/templates/index_map_info.hbs
+++ b/app/assets/javascripts/geoblacklight/templates/index_map_info.hbs
@@ -4,8 +4,8 @@
   </div>
   <div class="col-sm-12 index-map__table">
     {{#if thumbnailUrl}}
-      {{#if websiteUrl}}
-        <a href="{{websiteUrl}}" class="index-map__thumbnail">
+      {{#if iiifUrl}}
+        <a href="{{iiifUrl}}" class="index-map__thumbnail">
           <img src="{{thumbnailUrl}}" class="img-responsive">
         </a>
       {{else}}

--- a/app/assets/stylesheets/gem/_search-results.scss
+++ b/app/assets/stylesheets/gem/_search-results.scss
@@ -90,12 +90,6 @@
     & > div:first-of-type {
       width: 100%;
     }
-
-    .map-thumbnail {
-      height: 75px;
-      min-width: 75px;
-      background: $c-bg-light;
-    }
   }
 
   // map

--- a/app/views/catalog/_index_split_default.html.erb
+++ b/app/views/catalog/_index_split_default.html.erb
@@ -2,22 +2,10 @@
 <%= content_tag :div, class: 'documentHeader index-split row', data: { layer_id: document.id, geom: document.geometry.geojson } do %>
   <h3 class="index_title col">
     <% counter = document_counter_with_offset(document_counter) %>
-    <!-- <span class="document-counter">
-      <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
-    </span> -->
     <%= link_to_document document, counter: counter %>
   </h3>
   <span class='status-icons'>
     <%= render partial: 'header_icons', locals: { document: document } %>
-
-    <!-- <button
-      class="caret-toggle btn"
-      data-toggle="collapse"
-      data-target="#doc-<%= document.id %>-fields-collapse"
-      aria-label="<%= t('geoblacklight.metadata.toggle_summary') %>"
-      aria-expanded="false"
-      aria-controls="doc-<%= document.id %>-fields-collapse">
-    </button> -->
   </span>
 <% end %>
 
@@ -27,8 +15,5 @@
     <p>
       <%= geoblacklight_present(:index_fields_display, document) %>
     </p>
-  </div>
-  <div class="map-thumbnail">
-    Map
   </div>
 </div>


### PR DESCRIPTION
**Index map image links to viewer**
* * *

**JIRA Ticket**: [HGL-374: Index map explorer](https://jira.huit.harvard.edu/browse/HGL-374)

# What does this Pull Request do?
Thumbnail images in the index map explorer will now link to the viewer, if this link exists. Otherwise will just be a static thumbnail.

# How should this be tested?
Test case where thumbnail images link over the viewer: [Plans directeurs de guerre](https://localhost:3001/catalog/harvard-g5831-r3-s20-f7-index-gr)
- Open up the explorer, find one with an image, click on image.

Different institutions use the iiifUrl field differently, so others may link to the manifest: [Dabao Kinbōzu, Maps Index](https://localhost:3001/catalog/stanford-fb897vt9938)

Also removed placeholder image for the search results page thumbnails.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@phil-plencner-hl 
@enriquediaz 