### PR TITLE
Removed publisher and local ids from description field on search results page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -124,8 +124,8 @@ class CatalogController < ApplicationController
     config.add_index_field Settings.FIELDS.YEAR
     config.add_index_field Settings.FIELDS.CREATOR
     config.add_index_field Settings.FIELDS.DESCRIPTION, helper_method: :snippit
-    config.add_index_field Settings.FIELDS.PUBLISHER
-    config.add_index_field Settings.FIELDS.LOCALIDS
+    # config.add_index_field Settings.FIELDS.PUBLISHER
+    # config.add_index_field Settings.FIELDS.LOCALIDS
 
 
 


### PR DESCRIPTION
**Removed publisher and local ids from description field on search results page**
* * *

**JIRA Ticket**: [HGL-467: Remove collection ID from search results](https://jira.huit.harvard.edu/browse/HGL-467)

# What does this Pull Request do?
Removes publisher and local ids from description field on search results page

# How should this be tested?
Compare [local search results page](https://localhost:3001/?f%5Bdct_provenance_s%5D%5B%5D=Harvard&q=&search_field=all_fields) to [dev search results page](https://hgl-dev.lib.harvard.edu/?f%5Bdct_provenance_s%5D%5B%5D=Harvard&q=&search_field=all_fields) to confirm that
* Publisher information is removed from the end of the search description field
* Local id information is removed from the end of the search description field (looks like a random string of numbers)

Note: "AMS China : Ch'ang-chiang Region (Raster Image)" is a good example that had both fields visable

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@phil-plencner-hl 
@enriquediaz 