### PR TITLE
Changing cookie expiration to be minutes instead of seconds.

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -45,6 +45,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     token = JWT.encode payload, ENV['JWT_SECRET_KEY'], ENV['JWT_ALGORITHM']
 
     # Set the cookie
-    cookies[:hgl] = { :value => token, :domain => ENV['COOKIE_DOMAIN'], :expires => Time.now + ENV['COOKIE_MAX_AGE_MINS'].to_i }
+    cookies[:hgl] = { :value => token, :domain => ENV['COOKIE_DOMAIN'], :expires => Time.now + ENV['COOKIE_MAX_AGE_MINS'].to_i.minutes }
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 version: '3.8'
 services:
   app:
-    image: registry.lts.harvard.edu/lts/hgl:0.0.19
+    image: registry.lts.harvard.edu/lts/hgl:0.0.20
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
**Fix Expiration of HGL Cookie**
* * *

**JIRA Ticket**: none


# What does this Pull Request do?
This changes the expiration of the hgl cookie from 60 seconds to 60 minutes.

# How should this be tested?

A description of what steps someone could take to:
* After logging in with HarvardKey, confirm the expiration time of the hgl cookie is 60 minutes into the future.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests?  no

# Interested parties
@dl-maura 