### PR TITLE
Replace Harvard shield icon with full-color version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'jquery-rails'
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
 
-gem 'harvard-patterns-gem', '1.0', :git => 'https://gitlab.com/harvard-library-web-team/harvard-patterns-gem.git', :tag => '1.0'
+gem 'harvard-patterns-gem', '1.1', :git => 'https://gitlab.com/harvard-library-web-team/harvard-patterns-gem.git', :tag => '1.1'
 
 gem 'rails-healthcheck'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://gitlab.com/harvard-library-web-team/harvard-patterns-gem.git
-  revision: 3b93e8bd8e3e6261d9722fafb82e63a73c11d718
-  tag: 1.0
+  revision: 5ee485f2870bc76827d96dcd19c2bcd3fc58da78
+  tag: 1.1
   specs:
-    harvard-patterns-gem (1.0)
+    harvard-patterns-gem (1.1)
       rails
       sass
       sass-rails
@@ -457,7 +457,7 @@ DEPENDENCIES
   devise-guests (~> 0.6)
   geoblacklight
   geoserver-publish
-  harvard-patterns-gem (= 1.0)!
+  harvard-patterns-gem (= 1.1)!
   jbuilder (~> 2.5)
   jquery-rails
   jwt


### PR DESCRIPTION
**Replace Harvard shield icon with full-color version**
* * *

**JIRA Ticket**: [HGL-479](https://jira.huit.harvard.edu/browse/HGL-479)

* Other Relevant Links: [harvard-patterns-gem commit](https://gitlab.com/harvard-library-web-team/harvard-patterns-gem/-/commit/31bf0102bf2e2849c352fd346d8c53a553679340) (to see the actual style changes made)

# What does this Pull Request do?

- Replaces the gray Harvard shield icon with a crimson-colored version wherever the logo appears
- Updates gemfile to point to harvard-patterns-gem version 1.1

# How should this be tested?

* Rebuild HGL locally, check to see that's using `harvard-patterns-gem 1.1`
* Visually you will see a crimson Harvard logo appear on [search results page](https://localhost:3001/?utf8=%E2%9C%93&search_field=all_fields&q=ams+china) (in both the filter rail and the search results cards), and [Harvard item detail pages](https://localhost:3001/catalog/harvard-ams7810-s250-u54-ne49-1/track?counter=1&document_id=harvard-ams7810-s250-u54-ne49-1&search_id=35) (sidebar area)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? no

# Interested parties
@dl-maura @enriquediaz @mmcgee 